### PR TITLE
PayPal importer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ cardcomplete = ["fast-xml"]
 erste = []
 flatex = ["csv", "lopdf"]
 revolut = ["csv"]
-default = ["cardcomplete", "erste", "flatex", "revolut"]
+paypal = ["csv"]
+default = ["cardcomplete", "erste", "flatex", "revolut","paypal"]
 
 [dependencies]
 bigdecimal = { version = "0.4.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following bank export formats are supported:
 - card complete XML exports
 - flatex CSV exports of settlement accounts
 - flatex PDF invoice
+- PayPal tab-separated transaction exports
 
 ## Compile and Run
 
@@ -34,6 +35,7 @@ The following features are available:
 - erste
 - flatex
 - revolut
+- paypal
 
 All features are enabled per default.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "paypal")]
+use crate::importers::paypal::PayPalConfig;
 #[cfg(feature = "revolut")]
 use crate::importers::revolut::RevolutConfig;
 #[cfg(feature = "flatex")]
@@ -32,6 +34,8 @@ pub struct ImporterConfig {
     pub flatex_csv: Option<FlatexCsvConfig>,
     #[cfg(feature = "flatex")]
     pub flatex_pdf: Option<FlatexPdfConfig>,
+    #[cfg(feature = "paypal")]
+    pub paypal: Option<PayPalConfig>,
 }
 
 impl ImporterConfig {
@@ -348,6 +352,8 @@ mod tests {
             flatex_csv: None,
             #[cfg(feature = "flatex")]
             flatex_pdf: None,
+            #[cfg(feature = "paypal")]
+            paypal: None,
         };
         let result = toml::from_str::<ImporterConfig>(&config_str).expect("TOML parsing failed");
         assert_eq!(result, expected);
@@ -395,6 +401,8 @@ mod tests {
                 }],
             },
             fallback_account: None,
+            #[cfg(feature = "paypal")]
+            paypal: None,
             #[cfg(feature = "revolut")]
             revolut: None,
             #[cfg(feature = "flatex")]
@@ -489,6 +497,8 @@ mod tests {
             flatex_csv: None,
             #[cfg(feature = "flatex")]
             flatex_pdf: None,
+            #[cfg(feature = "paypal")]
+            paypal: None,
             categories: vec![
                 CategoryMapping {
                     pattern: "cat1".to_owned(),
@@ -562,6 +572,8 @@ mod tests {
             flatex_csv: None,
             #[cfg(feature = "flatex")]
             flatex_pdf: None,
+            #[cfg(feature = "paypal")]
+            paypal: None,
             categories: Vec::new(),
         };
         let result = toml::from_str::<ImporterConfig>(&config_str).expect("TOML parsing failed");

--- a/src/importers/mod.rs
+++ b/src/importers/mod.rs
@@ -17,3 +17,7 @@ pub mod flatex_csv;
 /// hledger importer for Flatex PDF invoices
 #[cfg(feature = "flatex")]
 pub mod flatex_inv;
+
+/// PayPal textfile importer for tab-separated PayPal exports
+#[cfg(feature = "paypal")]
+pub mod paypal;

--- a/src/importers/paypal.rs
+++ b/src/importers/paypal.rs
@@ -1,0 +1,188 @@
+use std::str::FromStr;
+
+use bigdecimal::{BigDecimal, Zero};
+use chrono::NaiveDate;
+
+use serde::Deserialize;
+
+use crate::{
+    error::*,
+    hledger::output::{Tag, Transaction},
+};
+use crate::{
+    hledger::output::{AmountAndCommodity, Posting, TransactionState},
+    HledgerImporter,
+};
+
+pub struct PaypalPdfImporter {}
+
+impl PaypalPdfImporter {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for PaypalPdfImporter {
+    fn default() -> Self {
+        PaypalPdfImporter::new()
+    }
+}
+
+impl HledgerImporter for PaypalPdfImporter {
+    fn parse(
+        &self,
+        input_file: &std::path::Path,
+        config: &crate::config::ImporterConfig,
+        _known_codes: &std::collections::HashSet<String>,
+    ) -> crate::error::Result<Vec<crate::hledger::output::Transaction>> {
+        let paypal_config = match &config.paypal {
+            Some(conf) => conf,
+            None => return Err(ImportError::MissingConfig("paypal".to_string())),
+        };
+
+        let mut transactions = Vec::new();
+        let mut reader = csv::ReaderBuilder::new()
+            .delimiter(b'\t')
+            .has_headers(true)
+            .double_quote(true)
+            .flexible(true)
+            .from_path(input_file)
+            .map_err(|e| ImportError::InputParse(e.to_string()))?;
+
+        for record in reader.deserialize::<PayPalTransaction>() {
+            let record = record.map_err(|e| ImportError::InputParse(e.to_string()))?;
+            let transaction = ConfiguredPaypalTransaction {
+                config: paypal_config,
+                transaction: &record,
+            };
+            let transaction: Transaction = transaction.try_into()?;
+            transactions.push(transaction);
+        }
+
+        Ok(transactions)
+    }
+
+    fn output_title(&self) -> &'static str {
+        "PayPal import"
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PayPalTransaction {
+    #[serde(rename = "Datum")]
+    pub posting_date: String,
+    #[serde[rename = "Uhrzeit"]]
+    pub posting_time: String,
+    #[serde[rename = "Zeitzone"]]
+    pub timezone: String,
+    #[serde[rename = "Name"]]
+    pub name: String,
+    #[serde[rename = "Typ"]]
+    pub transaction_type: String,
+    #[serde[rename = "Status"]]
+    pub status: String,
+    #[serde[rename = "Währung"]]
+    pub currency: String,
+    #[serde[rename = "Brutto"]]
+    pub gross_amount: String,
+    #[serde[rename = "Gebühr"]]
+    pub fee: String,
+    #[serde[rename = "Netto"]]
+    pub net_amount: String,
+}
+
+struct ConfiguredPaypalTransaction<'a> {
+    pub config: &'a PayPalConfig,
+    pub transaction: &'a PayPalTransaction,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct PayPalConfig {
+    pub fees_account: String,
+    pub asset_account: String,
+    pub clearing_account: String,
+    pub empty_payee: String,
+}
+
+impl TryInto<Transaction> for ConfiguredPaypalTransaction<'_> {
+    type Error = ImportError;
+
+    fn try_into(self) -> std::result::Result<Transaction, Self::Error> {
+        let date = NaiveDate::parse_from_str(&self.transaction.posting_date, "%d.%m.%Y")
+            .map_err(|e| ImportError::InputParse(e.to_string()))?;
+
+        let payee = if !self.transaction.name.trim().is_empty() {
+            self.transaction.name.trim().to_string()
+        } else {
+            self.config.empty_payee.to_string()
+        };
+
+        let gross_amount =
+            BigDecimal::from_str(&self.transaction.gross_amount.trim().replace(",", "."))
+                .map_err(|e| ImportError::InputParse(e.to_string()))?;
+
+        let gross_amount = AmountAndCommodity {
+            amount: gross_amount,
+            commodity: self.transaction.currency.clone(),
+        };
+
+        let mut postings = vec![Posting {
+            account: self.config.asset_account.clone(),
+            amount: Some(gross_amount),
+            comment: None,
+            tags: Vec::new(),
+        }];
+
+        let fee_amount = BigDecimal::from_str(&self.transaction.fee.trim().replace(",", "."))
+            .map_err(|e| ImportError::InputParse(e.to_string()))?;
+
+        if !fee_amount.is_zero() {
+            let fee_amount = AmountAndCommodity {
+                amount: fee_amount,
+                commodity: self.transaction.currency.clone(),
+            };
+            postings.push(Posting {
+                account: self.config.fees_account.clone(),
+                amount: Some(fee_amount),
+                comment: Some("transaction fee".to_string()),
+                tags: Vec::new(),
+            });
+        }
+
+        postings.push(Posting {
+            account: self.config.clearing_account.clone(),
+            amount: None,
+            comment: None,
+            tags: Vec::new(),
+        });
+
+        let t = Transaction {
+            date,
+            postings,
+            payee,
+            code: None,
+            comment: None,
+            state: TransactionState::Cleared,
+            note: Some(self.transaction.transaction_type.clone()),
+            tags: vec![
+                Tag {
+                    name: "time".to_string(),
+                    value: Some(self.transaction.posting_time.clone()),
+                },
+                Tag {
+                    name: "timezone".to_string(),
+                    value: Some(self.transaction.timezone.clone()),
+                },
+                Tag {
+                    name: "status".to_string(),
+                    value: Some(self.transaction.status.clone()),
+                },
+                Tag {
+                    name: "net_amount".to_string(),
+                    value: Some(self.transaction.net_amount.clone()),
+                },
+            ],
+        };
+        Ok(t)
+    }
+}

--- a/src/importers/revolut.rs
+++ b/src/importers/revolut.rs
@@ -428,6 +428,8 @@ TOPUP,Current,2024-05-19 10:02:45,2024-05-22 10:02:45,Payment from John Doe Jr,1
             flatex_csv: None,
             #[cfg(feature = "flatex")]
             flatex_pdf: None,
+            #[cfg(feature = "paypal")]
+            paypal: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,10 @@ enum Importer {
     /// Flatex PDF invoice (of stock exchange transactions)
     #[cfg(feature = "flatex")]
     FlatexPDF,
+
+    /// PayPal TXT (tab-separated) transaction list
+    #[cfg(feature = "paypal")]
+    Paypal,
 }
 
 impl From<Importer> for Box<dyn HledgerImporter> {
@@ -61,6 +65,8 @@ impl From<Importer> for Box<dyn HledgerImporter> {
             Importer::FlatexCSV => Box::new(importers::flatex_csv::FlatexCsvImport::new()),
             #[cfg(feature = "flatex")]
             Importer::FlatexPDF => Box::new(importers::flatex_inv::FlatexPdfInvoiceImporter::new()),
+            #[cfg(feature = "paypal")]
+            Importer::Paypal => Box::new(importers::paypal::PaypalPdfImporter::new()),
         }
     }
 }


### PR DESCRIPTION
importer for PayPal tab-separated export files.
The importer clears the asset account against a clearing account.

Closes #14