### PR TITLE
make output number formatting configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,7 +412,6 @@ dependencies = [
  "fast-xml",
  "homedir",
  "lopdf",
- "num-format",
  "regex",
  "serde",
  "serde_json",
@@ -612,17 +605,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-format"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
-dependencies = [
- "arrayvec",
- "itoa",
- "num-bigint",
-]
 
 [[package]]
 name = "num-integer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ csv = { version = "1.3.0", optional = true }
 fast-xml = { version = "0.23.1", features = ["serialize"], optional = true }
 homedir = "0.2.1"
 lopdf = { version = "0.32.0", optional = true }
-num-format = { version = "0.4.4", features = ["with-num-bigint"] }
 regex = "1.10.5"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = { version = "1.0.117" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use std::str::FromStr;
 pub struct ImporterConfig {
     #[serde(default)]
     pub hledger: HledgerConfig,
+    pub commodity_formatting_rules: Option<Vec<String>>,
     pub ibans: Vec<IbanMapping>,
     pub cards: Vec<CardMapping>,
     pub mapping: Vec<SimpleMapping>,
@@ -327,6 +328,7 @@ mod tests {
             hledger: HledgerConfig {
                 path: "/opt/homebrew/bin/hledger".to_owned(),
             },
+            commodity_formatting_rules: None,
             ibans: vec![],
             cards: vec![],
             mapping: vec![],
@@ -376,6 +378,7 @@ mod tests {
         .to_owned();
         let expected = ImporterConfig {
             hledger: HledgerConfig::default(),
+            commodity_formatting_rules: None,
             ibans: vec![],
             cards: vec![],
             mapping: vec![],
@@ -443,6 +446,7 @@ mod tests {
         .to_owned();
         let expected = ImporterConfig {
             hledger: HledgerConfig::default(),
+            commodity_formatting_rules: None,
             mapping: vec![],
             creditor_and_debitor_mapping: vec![],
             transfer_accounts: TransferAccounts {
@@ -526,6 +530,7 @@ mod tests {
         .to_owned();
         let expected = ImporterConfig {
             hledger: HledgerConfig::default(),
+            commodity_formatting_rules: None,
             mapping: vec![
                 SimpleMapping {
                     search: "Store".to_owned(),

--- a/src/hledger/format.rs
+++ b/src/hledger/format.rs
@@ -3,11 +3,27 @@ use std::process::{Command, Stdio};
 
 use crate::{config::HledgerConfig, error::*};
 
-pub fn hledger_format(config: &HledgerConfig, transactions: &str) -> Result<String> {
+pub fn hledger_format(
+    config: &HledgerConfig,
+    transactions: &str,
+    commodity_formatting_rules: &Option<Vec<String>>,
+) -> Result<String> {
+    let args: Vec<&str> = if let Some(rules) = commodity_formatting_rules {
+        dbg!(rules);
+        let mut args = vec!["print", "-x", "-f-", "--round=soft"];
+        rules.iter().for_each(|r| {
+            args.push("-c");
+            args.push(r);
+        });
+        args
+    } else {
+        dbg!("no formatting rules here :-( ");
+        vec!["print", "-x", "-f-"]
+    };
+    dbg!(&args);
+
     let mut process = Command::new(&config.path)
-        .arg("print")
-        .arg("-x")
-        .arg("-f-")
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/src/hledger/output.rs
+++ b/src/hledger/output.rs
@@ -12,46 +12,7 @@ pub struct AmountAndCommodity {
 
 impl Display for AmountAndCommodity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut result_amount = String::new();
-
-        let format = num_format::CustomFormat::builder()
-            .grouping(num_format::Grouping::Standard)
-            .minus_sign("-")
-            .separator(".")
-            .build()
-            .unwrap();
-
-        let mut amount_str = self.amount.to_string();
-
-        let negative = amount_str.starts_with('-');
-        if negative {
-            result_amount.push('-');
-        }
-
-        if !amount_str.contains('.') {
-            amount_str.push_str(".00");
-        }
-
-        let mut parts = amount_str.split('.');
-
-        // the part before the comma (before the decimal point)
-        if let Some(before_decimal) = parts.next() {
-            let mut buffer = num_format::Buffer::new();
-            let before_decimal = before_decimal.parse::<i64>().unwrap().abs();
-            buffer.write_formatted(&before_decimal, &format);
-            result_amount.push_str(buffer.as_str());
-        }
-
-        // the part after the comma (after the decimal point) - optional
-        if let Some(after_decimal) = parts.next() {
-            result_amount.push(',');
-            result_amount.push_str(after_decimal);
-            if after_decimal.len() < 2 {
-                result_amount.push('0');
-            }
-        }
-
-        write!(f, "{} {}", result_amount, &self.commodity)
+        write!(f, "{} {}", self.amount, &self.commodity)
     }
 }
 
@@ -265,40 +226,40 @@ mod tests {
             commodity: String::from("EUR"),
         };
         let result = amount.to_string();
-        assert_eq!(result, "-299.101,12 EUR");
+        assert_eq!(result, "-299101.12 EUR");
 
         let amount = AmountAndCommodity {
             amount: BigDecimal::from_str("1799361.99").unwrap(),
             commodity: String::from("EUR"),
         };
         let result = amount.to_string();
-        assert_eq!(result, "1.799.361,99 EUR");
+        assert_eq!(result, "1799361.99 EUR");
 
         let amount = AmountAndCommodity {
             amount: BigDecimal::from_str("0.12345678").unwrap(),
             commodity: String::from("BTC"),
         };
         let result = amount.to_string();
-        assert_eq!(result, "0,12345678 BTC");
+        assert_eq!(result, "0.12345678 BTC");
 
         let amount = AmountAndCommodity {
             amount: BigDecimal::from_str("22").unwrap(),
             commodity: String::from("GLD"),
         };
         let result = amount.to_string();
-        assert_eq!(result, "22,00 GLD");
+        assert_eq!(result, "22 GLD");
 
         let a = AmountAndCommodity {
             amount: BigDecimal::from_str("10").unwrap(),
             commodity: "EUR".to_owned(),
         };
-        assert_eq!(a.to_string(), "10,00 EUR");
+        assert_eq!(a.to_string(), "10 EUR");
 
         let a = AmountAndCommodity {
             amount: BigDecimal::from_str("12.1").unwrap(),
             commodity: "USD".to_owned(),
         };
-        assert_eq!(a.to_string(), "12,10 USD");
+        assert_eq!(a.to_string(), "12.1 USD");
     }
 
     #[test]
@@ -318,7 +279,7 @@ mod tests {
         let result = posting.to_string();
         assert_eq!(
             result,
-            "    Assets:Cash     -11,44 EUR\n    ; lunch:\n    ; valuation: 2024-05-02"
+            "    Assets:Cash     -11.44 EUR\n    ; lunch:\n    ; valuation: 2024-05-02"
         );
 
         let posting = Posting {
@@ -417,7 +378,7 @@ mod tests {
             ],
         };
         let result = t.to_string();
-        assert_eq!(result, "2020-06-18 * (123-XYZ-321) Store | Bought something\n    ; this is a test\n    Assets:Cash     -2.799,97 EUR\n    Expenses:Test\n    ; Some test");
+        assert_eq!(result, "2020-06-18 * (123-XYZ-321) Store | Bought something\n    ; this is a test\n    Assets:Cash     -2799.97 EUR\n    Expenses:Test\n    ; Some test");
 
         let t = Transaction {
             date: NaiveDate::from_ymd_opt(2020, 6, 18).unwrap(),
@@ -446,7 +407,7 @@ mod tests {
             ],
         };
         let result = t.to_string();
-        assert_eq!(result, "2020-06-18 * Store | Bought something\n    ; this is a test\n    Assets:Cash     -2.799,97 EUR\n    Expenses:Test\n    ; Some test");
+        assert_eq!(result, "2020-06-18 * Store | Bought something\n    ; this is a test\n    Assets:Cash     -2799.97 EUR\n    Expenses:Test\n    ; Some test");
     }
 
     #[test]
@@ -456,6 +417,6 @@ mod tests {
             commodity: "EUR".to_owned(),
         };
         let result = amount.to_string();
-        assert_eq!(result, "-0,01 EUR");
+        assert_eq!(result, "-0.01 EUR");
     }
 }

--- a/src/importers/revolut.rs
+++ b/src/importers/revolut.rs
@@ -394,6 +394,7 @@ TOPUP,Current,2024-05-19 10:02:45,2024-05-22 10:02:45,Payment from John Doe Jr,1
     fn test_config() -> ImporterConfig {
         ImporterConfig {
             hledger: HledgerConfig::default(),
+            commodity_formatting_rules: None,
             ibans: Vec::new(),
             cards: Vec::new(),
             mapping: vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,11 @@ fn main() {
             let transactions: Vec<String> = transactions.iter().map(|t| t.to_string()).collect();
             let transactions = transactions.join("\n");
 
-            let transactions = match hledger_format(&config.hledger, &transactions) {
+            let transactions = match hledger_format(
+                &config.hledger,
+                &transactions,
+                &config.commodity_formatting_rules,
+            ) {
                 Ok(t) => t,
                 Err(e) => {
                     eprintln!("[ERROR] {}", e);


### PR DESCRIPTION
extend configuration with `commodity_formatting_rules`. The rules are passed on to the `hledger print` call as commodity style rule (`-c`).

closes #4