### PR TITLE
Revolut: generate transaction hash as code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hledger-import"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hledger-import"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 
 [features]

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,0 +1,8 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+pub fn transaction_hash<T: Hash>(prefix: &str, transaction: &T) -> String {
+    let mut hasher = DefaultHasher::new();
+    transaction.hash(&mut hasher);
+    let hash = hasher.finish();
+    format!("{prefix}_{hash}")
+}

--- a/src/importers/revolut.rs
+++ b/src/importers/revolut.rs
@@ -1,4 +1,4 @@
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::Hash;
 use std::str::FromStr;
 
 use bigdecimal::{BigDecimal, Zero};
@@ -7,6 +7,7 @@ use serde::Deserialize;
 
 use crate::config::ImporterConfigTarget;
 use crate::error::Result;
+use crate::hasher::transaction_hash;
 use crate::hledger::output::AmountAndCommodity;
 use crate::{
     HledgerImporter,
@@ -104,7 +105,7 @@ impl RevolutTransaction {
             return Ok(None);
         }
 
-        let code = self.transaction_hash();
+        let code = transaction_hash("REVOLUT", &self);
         let state = self.state();
         let tags = self.tags();
         let postings = self.postings(config);
@@ -247,13 +248,6 @@ impl RevolutTransaction {
         };
 
         Ok(big_dec)
-    }
-
-    fn transaction_hash(&self) -> String {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        let hash = hasher.finish();
-        format!("REVOLUT_{hash}")
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use hledger::{format::hledger_format, output::HeaderComment};
 
 pub mod config;
 pub mod error;
+pub mod hasher;
 pub mod hledger;
 pub mod importers;
 


### PR DESCRIPTION
use default hasher to generate the hash value of the converted RevolutTransaction and prefix it with "REVOLUT_" to have an artificial code for the transaction.

belongs to #5