### PR TITLE
Erste importer. apply creditor_and_debitor_mapping to reference field

### DIFF
--- a/src/importers/erste.rs
+++ b/src/importers/erste.rs
@@ -226,7 +226,17 @@ impl ErsteTransaction {
         &self,
         config: &ImporterConfig,
     ) -> Result<Option<ImporterConfigTarget>> {
-        match &self.partner_name {
+        let partner_name = self
+            .partner_name
+            .as_ref()
+            .filter(|name| !name.is_empty())
+            .or_else(|| {
+                self.reference
+                    .as_ref()
+                    .filter(|ref_str| !ref_str.is_empty())
+            });
+
+        match &partner_name {
             Some(partner_name) => {
                 let search_amount: AmountAndCommodity = self.amount.clone().try_into()?;
 


### PR DESCRIPTION
For Erste VISA transactions the payee name is delivered in the "reference" field, so the creditor_and_debtior_mapping configurations should be applied to the "reference" field as well. The field "partner_name" will be preferred over "reference".

resolves #37